### PR TITLE
Future-proof against pandas default change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ install:
 - conda update -q conda
 - conda info -a
 - |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables pyyaml toolz psutil
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION cytoolz numpy pandas pip pytables pyyaml=3.13 toolz psutil
 - source activate test-environment
 - pip install orca openmatrix zbox
 - pip install pytest pytest-cov coveralls pycodestyle pytest-xdist
 - pip install sphinx numpydoc
-- pip --no-cache-dir install https://github.com/ActivitySim/activitysim/zipball/master
+- pip install activitysim==0.5.1
 - pip install .
 script:
 - pycodestyle rFirm

--- a/rFirm/steps/firm_synthesis.py
+++ b/rFirm/steps/firm_synthesis.py
@@ -1233,8 +1233,8 @@ def firm_synthesis(
     if REGRESS:
         regress(df=firm_io_pairs, step_name='firm_sim_iopairs', df_name='iopairs')
     if TRACE_TAZ is not None:
-            print "\nfirm_sim_iopairs TRACE_TAZ %s firm_input_output_pairs\n" % \
-                  TRACE_TAZ, firm_io_pairs[firm_io_pairs.TAZ == TRACE_TAZ].sort_values('bus_id')
+        print "\nfirm_sim_iopairs TRACE_TAZ %s firm_input_output_pairs\n" % \
+            TRACE_TAZ, firm_io_pairs[firm_io_pairs.TAZ == TRACE_TAZ].sort_values('bus_id')
 
     # - firm_sim_producers
     t0 = print_elapsed_time()

--- a/rFirm/steps/firm_synthesis.py
+++ b/rFirm/steps/firm_synthesis.py
@@ -374,7 +374,7 @@ def firm_sim_scale_employees(
     firms_foreign.index.name = firms.index.name
 
     # Combine the new firms with foreign firms
-    firms = pd.concat([firms, firms_foreign]).sort_index()
+    firms = pd.concat([firms, firms_foreign], sort=True).sort_index()
     assert firms.index.is_unique  # index (bus_id) should be unique
 
     # Recode employee counts into categories


### PR DESCRIPTION
Added explicit sort argument to pd.concat. Retaining current default
behavior to alphanumerically sort columns of final dataframe after a
row concatenation. Pandas default will change to not sorting in a future
version.